### PR TITLE
Add more margin for header tags.

### DIFF
--- a/scss/markdown/_header.scss
+++ b/scss/markdown/_header.scss
@@ -1,5 +1,5 @@
 @mixin header {
-  margin-top: 24px;
+  margin-top: 2em;
   margin-bottom: 16px;
   font-weight: 600;
   line-height: 1.25;


### PR DESCRIPTION
sample article: https://tech.crassone.jp/posts/introducing-faker-gem

| before | after |
| ------------- | ------------- |
| ![CleanShot 2021-03-30 at 17 31 48](https://user-images.githubusercontent.com/54310803/112959803-c4e23d00-917e-11eb-9251-f4d9d2ae944f.png) | ![CleanShot 2021-03-30 at 17 32 07](https://user-images.githubusercontent.com/54310803/112959833-ca3f8780-917e-11eb-8f74-4350657d0d43.png) |
